### PR TITLE
Fix typo in README (histroy → history)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Welcome to **Exsh**, A Unix like shell written in pure C. This project mimics th
 
 | Shell Feature                 | Exsh Implementation                                  |
 |-------------------------------|-----------------------------------------------------|
-| Interactive Prompt            | Tracks command histroy, `<C-r>` search and cursor control |
+| Interactive Prompt            | Tracks command history, `<C-r>` search and cursor control |
 | Command Execution             | Runs system commands with arguments                 |
 | Pipes                   | Connects output of one command to input of another |
 | Input/Output Redirection (`>`, `>>`, `<`) | Redirects stdin/stdout to files           |


### PR DESCRIPTION
Hi 👋

While reading the README, I noticed a small typo.
The word "histroy" has been corrected to "history".

Thanks for this awesome project!
