### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Welcome to **Exsh**, A Unix like shell written in pure C. This project mimics th
 
 | Shell Feature                 | Exsh Implementation                                  |
 |-------------------------------|-----------------------------------------------------|
-| Interactive Prompt            | Tracks command histroy, `<C-r>` search and cursor control |
+| Interactive Prompt            | Tracks command history, `<C-r>` search and cursor control |
 | Command Execution             | Runs system commands with arguments                 |
 | Pipes                   | Connects output of one command to input of another |
 | Input/Output Redirection (`>`, `>>`, `<`) | Redirects stdin/stdout to files           |


### PR DESCRIPTION
Fixed a minor typo in the README documentation.
Changed the typo "histroy" into "history".
